### PR TITLE
fixed compiler warning messages

### DIFF
--- a/drivers/cpufreq/cpufreq_interactive.c
+++ b/drivers/cpufreq/cpufreq_interactive.c
@@ -801,7 +801,8 @@ static ssize_t show_target_loads(
 		ret += sprintf(buf + ret, "%u%s", target_loads[i],
 			       i & 0x1 ? ":" : " ");
 
-	ret += sprintf(buf + --ret, "\n");
+	ret--;
+	ret += sprintf(buf + ret, "\n");
 	spin_unlock_irqrestore(&target_loads_lock, flags);
 	return ret;
 }
@@ -844,7 +845,8 @@ static ssize_t show_above_hispeed_delay(
 		ret += sprintf(buf + ret, "%u%s", above_hispeed_delay[i],
 			       i & 0x1 ? ":" : " ");
 
-	ret += sprintf(buf + --ret, "\n");
+	ret--;
+	ret += sprintf(buf + ret, "\n");
 	spin_unlock_irqrestore(&above_hispeed_delay_lock, flags);
 	return ret;
 }


### PR DESCRIPTION
drivers/cpufreq/cpufreq_interactive.c: In function ‘show_target_loads’:
drivers/cpufreq/cpufreq_interactive.c:804:6: warning: operation on ‘ret’ may be undefined [-Wsequence-point]
error, forbidden warning: cpufreq_interactive.c:804

Signed-off-by: Nucked <1286312989@qq.com>